### PR TITLE
Add automated release workflow for v0.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to use when manually triggering the release workflow'
+        required: true
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    env:
+      TAG_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name || github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore
+        run: dotnet restore GameHelper.sln
+
+      - name: Publish self-contained executable
+        run: >-
+          dotnet publish GameHelper.ConsoleHost/GameHelper.ConsoleHost.csproj
+          -c Release
+          -r win-x64
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:PublishTrimmed=false
+          -p:IncludeNativeLibrariesForSelfExtract=true
+
+      - name: Prepare artifacts
+        shell: pwsh
+        run: |
+          $publishDir = "GameHelper.ConsoleHost/bin/Release/net8.0-windows/win-x64/publish"
+          if (!(Test-Path $publishDir)) {
+            throw "Publish directory not found: $publishDir"
+          }
+          $tag = if ($env:TAG_NAME) { $env:TAG_NAME } else { $env:GITHUB_REF_NAME }
+          if (-not $tag) { $tag = "v0.0.1" }
+          $archiveName = "GameHelper-${tag}-win-x64.zip"
+          Compress-Archive -Path "$publishDir/*" -DestinationPath $archiveName
+          echo "ARCHIVE_NAME=$archiveName" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          files: ${{ env.ARCHIVE_NAME }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <Version>0.0.1</Version>
+    <FileVersion>0.0.1.0</FileVersion>
+    <AssemblyVersion>0.0.1.0</AssemblyVersion>
+    <InformationalVersion>0.0.1</InformationalVersion>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ dotnet publish .\GameHelper.ConsoleHost -c Release -r win-x64 --self-contained t
 ```
 产物：`GameHelper.ConsoleHost/bin/Release/net8.0-windows/win-x64/publish/`
 
+### GitHub Release 自动化
+
+仓库内置的 GitHub Actions 工作流会在推送形如 `v*` 的标签时自动构建自包含的 Win-x64 可执行文件，并将压缩包上传到 Release 资产中。如果你想发布 `0.0.1` 版本，可以执行：
+
+```powershell
+git tag v0.0.1
+git push origin v0.0.1
+```
+
+也可以通过 GitHub 页面手动触发 `Release` 工作流，并在输入参数中指定要发布的标签（例如 `v0.0.1`）。
+
 ### 发布后启动示例
 ```powershell
 $pub = ".\GameHelper.ConsoleHost\bin\Release\net8.0-windows\win-x64\publish"


### PR DESCRIPTION
## Summary
- set the solution version metadata to 0.0.1 so the published executable carries the requested version
- add a GitHub Actions workflow that builds a self-contained Windows executable and uploads it as a release asset when tags like v0.0.1 are pushed or the workflow is triggered manually
- document how to trigger the automated release for version 0.0.1 in the README

## Testing
- `dotnet test` *(fails: dotnet SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c4f22fc832cbdf3e43112f8f138