### PR TITLE
Enable returning to menu after monitor session

### DIFF
--- a/GameHelper.Tests/Interactive/InteractiveShellTests.cs
+++ b/GameHelper.Tests/Interactive/InteractiveShellTests.cs
@@ -140,13 +140,15 @@ namespace GameHelper.Tests.Interactive
             var console = CreateConsole();
             var script = new InteractiveScript()
                 .Enqueue("Monitor")
-                .Enqueue("开始监控");
+                .Enqueue("开始监控")
+                .Enqueue("q")
+                .Enqueue("Exit");
 
             var sessionStart = new DateTime(2024, 2, 2, 21, 15, 0, DateTimeKind.Unspecified);
-            async Task HostRunner(IHost _)
+            Task HostRunner(IHost _, CancellationToken token)
             {
                 scope.AppendPlaytimeSession("eldenring.exe", sessionStart, sessionStart.AddMinutes(45), 45);
-                await Task.CompletedTask;
+                return Task.CompletedTask;
             }
 
             var shell = new InteractiveShell(host, new ParsedArguments(), console, script, HostRunner);
@@ -175,6 +177,8 @@ namespace GameHelper.Tests.Interactive
             var services = new ServiceCollection()
                 .AddSingleton<IConfigProvider>(configProvider)
                 .AddSingleton<IAppConfigProvider>(configProvider)
+                .AddSingleton<IProcessMonitor, FakeProcessMonitor>()
+                .AddSingleton<IGameAutomationService, FakeAutomationService>()
                 .BuildServiceProvider();
 
             return new AsyncDisposableHost(services);
@@ -261,6 +265,49 @@ namespace GameHelper.Tests.Interactive
                 {
                     _appConfig = appConfig;
                 }
+            }
+        }
+
+        private sealed class FakeProcessMonitor : IProcessMonitor
+        {
+            public event Action<string>? ProcessStarted
+            {
+                add { }
+                remove { }
+            }
+
+            public event Action<string>? ProcessStopped
+            {
+                add { }
+                remove { }
+            }
+
+            public void Start()
+            {
+                // No-op for tests.
+            }
+
+            public void Stop()
+            {
+                // No-op for tests.
+            }
+
+            public void Dispose()
+            {
+                // Nothing to dispose.
+            }
+        }
+
+        private sealed class FakeAutomationService : IGameAutomationService
+        {
+            public void Start()
+            {
+                // No-op for tests.
+            }
+
+            public void Stop()
+            {
+                // No-op for tests.
             }
         }
 


### PR DESCRIPTION
## Summary
- allow the interactive monitor session to stop with the Q key instead of Ctrl+C and continue back to the main menu
- run the automation and process monitor services directly while awaiting a cancellable exit loop that intercepts Ctrl+C and redirected input
- extend the interactive shell tests to script the new exit flow and provide fake infrastructure services

## Testing
- dotnet build GameHelper.sln
- dotnet test GameHelper.sln

------
https://chatgpt.com/codex/tasks/task_e_68cffbaf7628832cbd3f51ce2c7f1f0e