### PR TITLE
Add auto-start monitor option to interactive shell

### DIFF
--- a/GameHelper.ConsoleHost/Interactive/InteractiveScript.cs
+++ b/GameHelper.ConsoleHost/Interactive/InteractiveScript.cs
@@ -44,6 +44,30 @@ namespace GameHelper.ConsoleHost.Interactive
             throw new InvalidOperationException($"Scripted response '{next}' cannot be converted to {typeof(T)}.");
         }
 
+        /// <summary>
+        /// Attempts to peek at the next value without removing it from the queue.
+        /// </summary>
+        /// <typeparam name="T">Expected type.</typeparam>
+        /// <param name="value">Output value when available.</param>
+        /// <returns>True when the script can expose the next value as the requested type.</returns>
+        public bool TryPeek<T>(out T value)
+        {
+            if (_responses.Count == 0)
+            {
+                value = default!;
+                return false;
+            }
+
+            var next = _responses.Peek();
+            if (TryConvert(next, out value))
+            {
+                return true;
+            }
+
+            value = default!;
+            return false;
+        }
+
         private static bool TryConvert<T>(object? input, out T value)
         {
             if (input is T direct)

--- a/GameHelper.Core/Models/AppConfig.cs
+++ b/GameHelper.Core/Models/AppConfig.cs
@@ -16,5 +16,10 @@ namespace GameHelper.Core.Models
         /// Type of process monitor to use. If not specified, defaults to WMI for backward compatibility.
         /// </summary>
         public ProcessMonitorType? ProcessMonitorType { get; set; }
+
+        /// <summary>
+        /// When enabled, the interactive shell will automatically start the monitor after launch.
+        /// </summary>
+        public bool AutoStartInteractiveMonitor { get; set; }
     }
 }

--- a/GameHelper.Tests/AssemblyInfo.cs
+++ b/GameHelper.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/GameHelper.Tests/Interactive/InteractiveShellTests.cs
+++ b/GameHelper.Tests/Interactive/InteractiveShellTests.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace GameHelper.Tests.Interactive
 {
+    [Collection("InteractiveShellSequential")]
     public class InteractiveShellTests
     {
         private readonly ITestOutputHelper _output;
@@ -140,6 +141,7 @@ namespace GameHelper.Tests.Interactive
             var console = CreateConsole();
             var script = new InteractiveScript()
                 .Enqueue("Monitor")
+                .Enqueue("Q")
                 .Enqueue("Exit");
 
             var sessionStart = new DateTime(2024, 2, 2, 21, 15, 0, DateTimeKind.Unspecified);
@@ -204,6 +206,40 @@ namespace GameHelper.Tests.Interactive
             Assert.Equal(0, monitor.StopCalls);
             Assert.Equal(0, automation.StartCalls);
             Assert.Equal(0, automation.StopCalls);
+        }
+
+        [Fact]
+        public async Task RunAsync_AutoStartMonitorOnLaunch_ExitsAfterQuitCommand()
+        {
+            using var scope = new AppDataScope();
+
+            var configProvider = new FakeConfigProvider(new Dictionary<string, GameConfig>
+            {
+                ["auto.exe"] = new GameConfig { Name = "auto.exe", Alias = "Auto Game", IsEnabled = true, HDREnabled = true }
+            },
+            new AppConfig { ProcessMonitorType = ProcessMonitorType.ETW, AutoStartInteractiveMonitor = true },
+            configPath: scope.ConfigPath);
+
+            await using var host = CreateHost(configProvider);
+            var console = CreateConsole();
+            var script = new InteractiveScript()
+                .Enqueue("Q")
+                .Enqueue(4);
+
+            var monitor = (FakeProcessMonitor)host.Services.GetRequiredService<IProcessMonitor>();
+            var automation = (FakeAutomationService)host.Services.GetRequiredService<IGameAutomationService>();
+
+            var shell = new InteractiveShell(host, new ParsedArguments(), console, script);
+            await shell.RunAsync();
+
+            var snapshot = console.Output.ToString();
+            _output.WriteLine("[AutoStart Snapshot]\n" + snapshot);
+
+            Assert.Contains("自动启动", snapshot);
+            Assert.Equal(1, monitor.StartCalls);
+            Assert.Equal(1, monitor.StopCalls);
+            Assert.Equal(1, automation.StartCalls);
+            Assert.Equal(1, automation.StopCalls);
         }
 
         private static TestConsole CreateConsole()
@@ -296,7 +332,8 @@ namespace GameHelper.Tests.Interactive
                             IsEnabled = v.IsEnabled,
                             HDREnabled = v.HDREnabled
                         }).ToList(),
-                        ProcessMonitorType = _appConfig.ProcessMonitorType
+                        ProcessMonitorType = _appConfig.ProcessMonitorType,
+                        AutoStartInteractiveMonitor = _appConfig.AutoStartInteractiveMonitor
                     };
                 }
             }
@@ -424,5 +461,10 @@ namespace GameHelper.Tests.Interactive
                 }
             }
         }
+    }
+
+    [CollectionDefinition("InteractiveShellSequential", DisableParallelization = true)]
+    public sealed class InteractiveShellSequentialCollection : ICollectionFixture<object>
+    {
     }
 }

--- a/docs/CLI_Manual_zh.md
+++ b/docs/CLI_Manual_zh.md
@@ -55,6 +55,8 @@
 - 字符串比较：对进程名大小写不敏感（如 `WITCHER3.EXE` 与 `witcher3.exe` 等价）
 - YAML 格式（支持别名 Alias）：
   ```yaml
+  processMonitorType: ETW # 可选：覆盖进程监听实现
+  autoStartInteractiveMonitor: true # 可选：进入互动命令行后自动启动监控
   games:
     - name: "witcher3.exe"
       alias: "巫师3"
@@ -65,6 +67,7 @@
 - `Name` 为唯一标识（规范 exe 名）。
 - `Alias` 为可选的显示名称，不影响匹配与统计，只影响显示。
 - `hDREnabled` 为未来 HDR 控制器使用的标记，当前不会实际切换 HDR。
+- `autoStartInteractiveMonitor` 设为 `true` 时，启动互动命令行会直接进入“实时监控”，按 `Q` 可以返回主菜单。
 
 ### 旧配置迁移
 - 如你仍有旧的 `config.json`，可运行一次：


### PR DESCRIPTION
## Summary
- add an AutoStartInteractiveMonitor setting to the app config model and interactive shell to launch monitoring immediately when enabled
- extend the interactive script/shell to handle scripted quit commands and cover the scenario with new tests
- document the new configuration flag and disable test parallelization for console-driven tests

## Testing
- dotnet build GameHelper.sln
- dotnet test GameHelper.sln

------
https://chatgpt.com/codex/tasks/task_e_68d40386f7f4832ca12d1f69ad50acdc