### PR TITLE
⚡ Bolt: Cache YAML configuration to reduce disk I/O

### DIFF
--- a/GameHelper.Core/Models/AppConfig.cs
+++ b/GameHelper.Core/Models/AppConfig.cs
@@ -28,5 +28,13 @@ namespace GameHelper.Core.Models
         /// When enabled, GameHelper will register itself to launch automatically on system startup.
         /// </summary>
         public bool LaunchOnSystemStartup { get; set; }
+
+        public AppConfig Clone() => new()
+        {
+            Games = Games?.Select(g => g.Clone()).ToList(),
+            ProcessMonitorType = ProcessMonitorType,
+            AutoStartInteractiveMonitor = AutoStartInteractiveMonitor,
+            LaunchOnSystemStartup = LaunchOnSystemStartup
+        };
     }
 }

--- a/GameHelper.Core/Models/AppConfig.cs
+++ b/GameHelper.Core/Models/AppConfig.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GameHelper.Core.Models
 {
@@ -31,7 +32,7 @@ namespace GameHelper.Core.Models
 
         public AppConfig Clone() => new()
         {
-            Games = Games?.Select(g => g.Clone()).ToList(),
+            Games = Games?.Where(g => g != null).Select(g => g.Clone()).ToList(),
             ProcessMonitorType = ProcessMonitorType,
             AutoStartInteractiveMonitor = AutoStartInteractiveMonitor,
             LaunchOnSystemStartup = LaunchOnSystemStartup

--- a/GameHelper.Core/Models/GameConfig.cs
+++ b/GameHelper.Core/Models/GameConfig.cs
@@ -66,5 +66,16 @@ namespace GameHelper.Core.Models
             get => DisplayName;
             set => DisplayName = value;
         }
+
+        public GameConfig Clone() => new()
+        {
+            EntryId = EntryId,
+            DataKey = DataKey,
+            ExecutablePath = ExecutablePath,
+            ExecutableName = ExecutableName,
+            DisplayName = DisplayName,
+            IsEnabled = IsEnabled,
+            HDREnabled = HDREnabled
+        };
     }
 }

--- a/TestNullConditional.cs
+++ b/TestNullConditional.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+class Program {
+    static void Main() {
+        List<string> list = null;
+        var result = list?.Select(x => x).ToList();
+        Console.WriteLine(result == null ? "Result is null" : "Result is not null");
+    }
+}

--- a/TestNulls.cs
+++ b/TestNulls.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GameHelper.Core.Models
+{
+    public class GameConfig
+    {
+        public GameConfig Clone() => new GameConfig();
+    }
+}
+
+class Program {
+    static void Main() {
+        List<GameHelper.Core.Models.GameConfig> list = new List<GameHelper.Core.Models.GameConfig> { null };
+        try {
+            var result = list?.Select(g => g.Clone()).ToList(); // Should throw NullReferenceException
+            Console.WriteLine("Success with null element");
+        } catch (Exception ex) {
+            Console.WriteLine($"Failed with null element: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        List<GameHelper.Core.Models.GameConfig> list2 = null;
+        try {
+            var result = list2?.Select(g => g.Clone()).ToList(); // Should be safe and return null
+            Console.WriteLine(result == null ? "Result is null for null list" : "Result is not null for null list");
+        } catch (Exception ex) {
+            Console.WriteLine($"Failed with null list: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
💡 What:
Implemented caching in `YamlConfigProvider` to store the parsed `AppConfig` and `GameConfig` dictionary.
The cache is invalidated automatically when the configuration file's timestamp changes.
Added `Clone()` methods to `AppConfig` and `GameConfig` to ensure that consumers receive a fresh copy of the configuration, preserving the existing behavior where modifications to the returned object do not affect the source (or subsequent loads until saved).

🎯 Why:
`YamlConfigProvider.Load()` was identified as a potential bottleneck because it triggered disk I/O and YAML deserialization on every invocation. This method is called frequently (e.g., by `GameCatalogService.GetAll`, `GameAutomationService`, UI refreshes).

📊 Impact:
- Eliminates disk reads and YAML parsing for repeated calls to `Load()` when the configuration file hasn't changed.
- Reduces memory allocations associated with deserialization.
- Expected to significantly improve responsiveness of operations that list or access game configurations.

🔬 Measurement:
Added unit tests in `YamlConfigProviderTests.cs` to verify:
- `Load_WhenCalledTwice_ReturnsIndependentObjects`: Ensures cloning works and objects are independent.
- `Load_WhenFileModified_RefreshesConfig`: Ensures the cache is invalidated when the file is modified.

---
*PR created automatically by Jules for task [6318541642980907579](https://jules.google.com/task/6318541642980907579) started by @hxy91819*