### PR TITLE
⚡ Bolt: Optimize ToSummary loop calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - [LINQ vs Single-Pass Loop Optimization]
+**Learning:** Found an opportunity to replace multiple LINQ queries (`Sum` and `Where().Sum()`) iterating over the same collection with a single-pass `foreach` loop in `GameHelper.Core/Services/StatisticsService.cs`. This specific architecture was performing O(2n) operations where O(n) would suffice, and reducing LINQ overhead in this statistics calculation hot-path provides a cleaner execution with fewer allocations.
+**Action:** When calculating multiple aggregates or filtered aggregates from the same collection, prefer a single `foreach` pass over chaining multiple LINQ operations to reduce both iterations and memory allocations.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-13 - [LINQ vs Single-Pass Loop Optimization]
 **Learning:** Found an opportunity to replace multiple LINQ queries (`Sum` and `Where().Sum()`) iterating over the same collection with a single-pass `foreach` loop in `GameHelper.Core/Services/StatisticsService.cs`. This specific architecture was performing O(2n) operations where O(n) would suffice, and reducing LINQ overhead in this statistics calculation hot-path provides a cleaner execution with fewer allocations.
 **Action:** When calculating multiple aggregates or filtered aggregates from the same collection, prefer a single `foreach` pass over chaining multiple LINQ operations to reduce both iterations and memory allocations.
+
+## 2025-02-13 - [LINQ Sum semantics: Checked vs Unchecked]
+**Learning:** LINQ's `Sum()` method performs additions in a `checked` context (throwing an OverflowException if the value overflows), whereas standard C# arithmetic operators like `+=` in a `foreach` loop execute in an `unchecked` context by default unless specified otherwise.
+**Action:** When replacing LINQ `Sum()` with standard loops for optimization, evaluate if overflow behavior needs to be preserved. If so, wrap the accumulation logic in a `checked { ... }` block to ensure consistent fast-fail behavior.

--- a/GameHelper.Core/Services/StatisticsService.cs
+++ b/GameHelper.Core/Services/StatisticsService.cs
@@ -69,12 +69,25 @@ public sealed class StatisticsService : IStatisticsService
             .OrderByDescending(item => item.StartTime)
             .ToList();
 
+        long totalMinutes = 0;
+        long recentMinutes = 0;
+
+        // Optimization: Calculate both totals in a single pass instead of multiple LINQ allocations
+        foreach (var session in record.Sessions)
+        {
+            totalMinutes += session.DurationMinutes;
+            if (session.EndTime >= cutoff)
+            {
+                recentMinutes += session.DurationMinutes;
+            }
+        }
+
         return new GameStatsSummary
         {
             GameName = record.GameName,
             DisplayName = displayName,
-            TotalMinutes = record.Sessions.Sum(item => item.DurationMinutes),
-            RecentMinutes = record.Sessions.Where(item => item.EndTime >= cutoff).Sum(item => item.DurationMinutes),
+            TotalMinutes = totalMinutes,
+            RecentMinutes = recentMinutes,
             SessionCount = record.Sessions.Count,
             Sessions = orderedSessions
         };

--- a/GameHelper.Core/Services/StatisticsService.cs
+++ b/GameHelper.Core/Services/StatisticsService.cs
@@ -73,12 +73,16 @@ public sealed class StatisticsService : IStatisticsService
         long recentMinutes = 0;
 
         // Optimization: Calculate both totals in a single pass instead of multiple LINQ allocations
-        foreach (var session in record.Sessions)
+        // LINQ Sum performs checked additions. We must preserve that behavior.
+        checked
         {
-            totalMinutes += session.DurationMinutes;
-            if (session.EndTime >= cutoff)
+            foreach (var session in record.Sessions)
             {
-                recentMinutes += session.DurationMinutes;
+                totalMinutes += session.DurationMinutes;
+                if (session.EndTime >= cutoff)
+                {
+                    recentMinutes += session.DurationMinutes;
+                }
             }
         }
 


### PR DESCRIPTION
💡 **What**: Replaced two separate LINQ queries (`Sum()` and `Where().Sum()`) iterating over the `record.Sessions` collection with a single `foreach` loop inside `GameHelper.Core/Services/StatisticsService.cs`.
🎯 **Why**: The original implementation was doing O(2n) operations because it looped through the `record.Sessions` collection twice. Replacing it with a single `foreach` loop reduces the operation to O(n) and removes overhead associated with enumerator and closure allocations from LINQ.
📊 **Impact**: Reduces iterations over the sessions collection by 50% during stats summary generation, lowering memory allocations and reducing CPU time spent in LINQ internal closures.
🔬 **Measurement**: Verify by running `dotnet build GameHelper.sln` and `dotnet test GameHelper.sln`. The functionality and data metrics should continue to be accurate (all tests pass).

---
*PR created automatically by Jules for task [18235816522990384360](https://jules.google.com/task/18235816522990384360) started by @hxy91819*