### PR TITLE
⚡ Bolt: [performance improvement] Optimize LINQ aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-08 - Optimize multiple LINQ iterations
+**Learning:** The memory context specifies: 'When calculating multiple aggregates from the same collection, prefer a single 'foreach' pass over chaining multiple LINQ operations (like multiple '.Sum()' or '.Where().Sum()') to reduce iterations and memory allocations.'
+**Action:** Update InteractiveShell.cs to use a single foreach loop when calculating TotalMinutes, RecentMinutes, and Sessions instead of calling .Sum() and .Where().Sum() multiple times on the same collection.

--- a/GameHelper.ConsoleHost/Commands/StatsCommand.cs
+++ b/GameHelper.ConsoleHost/Commands/StatsCommand.cs
@@ -54,12 +54,24 @@ public static class StatsCommand
 
         if (string.IsNullOrWhiteSpace(filterGame))
         {
+            // ⚡ Bolt: Single pass aggregation instead of multiple stats.Sum() calls.
+            long totalMinutes = 0;
+            long recentMinutes = 0;
+            long sessionCount = 0;
+
+            foreach (var item in stats)
+            {
+                totalMinutes += item.TotalMinutes;
+                recentMinutes += item.RecentMinutes;
+                sessionCount += item.SessionCount;
+            }
+
             rows.Add(new[]
             {
                 "TOTAL",
-                DurationFormatter.Format(stats.Sum(item => item.TotalMinutes)),
-                DurationFormatter.Format(stats.Sum(item => item.RecentMinutes)),
-                stats.Sum(item => item.SessionCount).ToString()
+                DurationFormatter.Format(totalMinutes),
+                DurationFormatter.Format(recentMinutes),
+                sessionCount.ToString()
             });
         }
 

--- a/GameHelper.ConsoleHost/Interactive/InteractiveShell.cs
+++ b/GameHelper.ConsoleHost/Interactive/InteractiveShell.cs
@@ -1209,17 +1209,37 @@ namespace GameHelper.ConsoleHost.Interactive
             var now = DateTime.Now;
             var cutoff = now.AddDays(-14);
 
-            var projected = list.Select(g => new
+            // ⚡ Bolt: Use a single-pass loop instead of multiple LINQ passes (.Sum, .Where().Sum)
+            // to calculate TotalMinutes and RecentMinutes. This reduces CPU overhead and memory allocations.
+            var projectedRaw = new List<(string Name, long TotalMinutes, long RecentMinutes, int Sessions)>(list.Count);
+            foreach (var g in list)
             {
-                Name = ResolveDisplayName(g.GameName, configLookup),
-                TotalMinutes = g.Sessions?.Sum(s => s.DurationMinutes) ?? 0,
-                RecentMinutes = g.Sessions?.Where(s => s.EndTime >= cutoff).Sum(s => s.DurationMinutes) ?? 0,
-                Sessions = g.Sessions?.Count ?? 0
-            })
-            .OrderByDescending(x => x.RecentMinutes)
-            .ThenByDescending(x => x.TotalMinutes)
-            .ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+                long totalMinutes = 0;
+                long recentMinutes = 0;
+                int sessionsCount = 0;
+
+                if (g.Sessions != null)
+                {
+                    sessionsCount = g.Sessions.Count;
+                    foreach (var s in g.Sessions)
+                    {
+                        totalMinutes += s.DurationMinutes;
+                        if (s.EndTime >= cutoff)
+                        {
+                            recentMinutes += s.DurationMinutes;
+                        }
+                    }
+                }
+
+                projectedRaw.Add((ResolveDisplayName(g.GameName, configLookup), totalMinutes, recentMinutes, sessionsCount));
+            }
+
+            var projected = projectedRaw
+                .Select(x => new { x.Name, x.TotalMinutes, x.RecentMinutes, x.Sessions })
+                .OrderByDescending(x => x.RecentMinutes)
+                .ThenByDescending(x => x.TotalMinutes)
+                .ThenBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
             if (projected.Count == 0)
             {
@@ -1245,9 +1265,18 @@ namespace GameHelper.ConsoleHost.Interactive
 
             if (string.IsNullOrWhiteSpace(filter))
             {
-                var totalAll = projected.Sum(p => p.TotalMinutes);
-                var totalRecent = projected.Sum(p => p.RecentMinutes);
-                var totalSessions = projected.Sum(p => p.Sessions);
+                // ⚡ Bolt: Single pass aggregation instead of multiple projected.Sum() calls.
+                long totalAll = 0;
+                long totalRecent = 0;
+                int totalSessions = 0;
+
+                foreach (var p in projected)
+                {
+                    totalAll += p.TotalMinutes;
+                    totalRecent += p.RecentMinutes;
+                    totalSessions += p.Sessions;
+                }
+
                 table.AddEmptyRow();
                 table.AddRow("[bold]TOTAL[/]",
                     $"[bold]{DurationFormatter.Format(totalAll)}[/]",
@@ -1900,9 +1929,23 @@ namespace GameHelper.ConsoleHost.Interactive
 
             _console.Write(table);
 
-            var aggregated = newSessions
-                .GroupBy(r => r.DisplayName)
-                .Select(g => new { g.Key, Minutes = g.Sum(r => r.DurationMinutes), Count = g.Count() })
+            // ⚡ Bolt: Use a single-pass Dictionary aggregation instead of .GroupBy().Select()
+            // to calculate Minutes and Count simultaneously. Reduces allocations.
+            var aggregatedDict = new Dictionary<string, (long Minutes, int Count)>(StringComparer.Ordinal);
+            foreach (var r in newSessions)
+            {
+                if (aggregatedDict.TryGetValue(r.DisplayName, out var current))
+                {
+                    aggregatedDict[r.DisplayName] = (current.Minutes + r.DurationMinutes, current.Count + 1);
+                }
+                else
+                {
+                    aggregatedDict[r.DisplayName] = (r.DurationMinutes, 1);
+                }
+            }
+
+            var aggregated = aggregatedDict
+                .Select(kv => new { Key = kv.Key, kv.Value.Minutes, kv.Value.Count })
                 .OrderByDescending(x => x.Minutes)
                 .ToList();
 


### PR DESCRIPTION
💡 What: Replaced multi-pass LINQ enumerations `.Sum()` and `.Where().Sum()` with single pass `foreach` loops in `InteractiveShell.cs` and `StatsCommand.cs`. Also replaced `.GroupBy().Select()` chain with Dictionary aggregation in `RenderSessionSummary`.

🎯 Why: Avoids repetitive enumeration of `IEnumerable<T>` to calculate multiple statistics, saving CPU cycles and reducing heap memory allocations.

📊 Impact: Reduces array enumerations significantly during game statistics calculations. Reduced heap memory allocation due to replacement of closure delegate evaluation.

🔬 Measurement: Monitored through standard testing (`dotnet test`).

---
*PR created automatically by Jules for task [7371185371166070916](https://jules.google.com/task/7371185371166070916) started by @hxy91819*