### PR TITLE
⚡ Bolt: [performance improvement] Optimize LINQ iterations in StatisticsService.ToSummary

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-15 - Optimize LINQ multiple passes to single foreach
+**Learning:** When calculating multiple aggregates (e.g. TotalMinutes and RecentMinutes) from the same collection, chaining multiple LINQ operations (like `.Sum()` and `.Where().Sum()`) causes unnecessary iterations and memory allocations.
+**Action:** Prefer a single `foreach` pass to calculate all required aggregates simultaneously, especially in critical paths.

--- a/GameHelper.Core/Services/StatisticsService.cs
+++ b/GameHelper.Core/Services/StatisticsService.cs
@@ -69,12 +69,26 @@ public sealed class StatisticsService : IStatisticsService
             .OrderByDescending(item => item.StartTime)
             .ToList();
 
+        long totalMinutes = 0;
+        long recentMinutes = 0;
+
+        // Bolt optimization: Single pass loop over sessions
+        // Avoids multiple LINQ allocations and iterations (.Sum() and .Where().Sum())
+        foreach (var session in record.Sessions)
+        {
+            totalMinutes += session.DurationMinutes;
+            if (session.EndTime >= cutoff)
+            {
+                recentMinutes += session.DurationMinutes;
+            }
+        }
+
         return new GameStatsSummary
         {
             GameName = record.GameName,
             DisplayName = displayName,
-            TotalMinutes = record.Sessions.Sum(item => item.DurationMinutes),
-            RecentMinutes = record.Sessions.Where(item => item.EndTime >= cutoff).Sum(item => item.DurationMinutes),
+            TotalMinutes = totalMinutes,
+            RecentMinutes = recentMinutes,
             SessionCount = record.Sessions.Count,
             Sessions = orderedSessions
         };


### PR DESCRIPTION
💡 **What:**
Replaced multiple LINQ operations (`.Sum()` and `.Where().Sum()`) with a single `foreach` loop in `StatisticsService.ToSummary`.

🎯 **Why:**
When calculating both `TotalMinutes` and `RecentMinutes` from `record.Sessions`, chaining multiple LINQ operations causes the code to iterate over the collection multiple times. Additionally, LINQ `.Where()` and `.Sum()` generate compiler closures and iterator state machines which cause unnecessary memory allocations in the managed heap. A single `foreach` loop is more performant as it calculates both aggregates in one pass without extra allocations.

📊 **Impact:**
- Reduces collection iterations from two to one.
- Eliminates memory allocations from `IEnumerable` iterators.
- Improves performance of generating playtime summaries, particularly when processing games with a large history of playtime sessions.

🔬 **Measurement:**
- Verified that the logic inside the loop perfectly mirrors the original `.Sum()` conditions.
- Validated via codebase review since `dotnet test` was unavailable due to local missing SDK 8.0.417 constraints (and instructions not to alter global.json). The behavior is mathematically identical.

---
*PR created automatically by Jules for task [17564420439917578070](https://jules.google.com/task/17564420439917578070) started by @hxy91819*