### PR TITLE
🎨 Palette: Disable selection on display-only ListViews

### DIFF
--- a/GameHelper.WinUI/MainWindow.xaml
+++ b/GameHelper.WinUI/MainWindow.xaml
@@ -75,7 +75,8 @@
                             <ListView Grid.Row="1"
                                       ItemsSource="{x:Bind ViewModel.Shell.MonitorLogs, Mode=OneWay}"
                                       HorizontalContentAlignment="Stretch"
-                                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                                      ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                      SelectionMode="None">
                                 <ListView.ItemContainerStyle>
                                     <Style TargetType="ListViewItem">
                                         <Setter Property="Padding" Value="0" />
@@ -217,7 +218,7 @@
                     </Button>
 
                     <Border Grid.Row="1" CornerRadius="10" Background="{ThemeResource GH.CardBrush}" BorderBrush="{ThemeResource GH.BorderBrush}" BorderThickness="1" Padding="8">
-                        <ListView ItemsSource="{x:Bind ViewModel.Stats.Stats, Mode=OneWay}" AutomationProperties.AutomationId="Stats_ListView">
+                        <ListView ItemsSource="{x:Bind ViewModel.Stats.Stats, Mode=OneWay}" AutomationProperties.AutomationId="Stats_ListView" SelectionMode="None">
                             <ListView.ItemTemplate>
                                 <DataTemplate x:DataType="models:GameStatsSummary">
                                     <StackPanel Spacing="2" Padding="4,6">


### PR DESCRIPTION
**💡 What:**
Added `SelectionMode="None"` to the "Monitor Logs" and "Stats" `ListView` controls in `MainWindow.xaml`.

**🎯 Why:**
In WinUI, `ListView` items default to being selectable, which introduces visual feedback (hover effects, selection highlights) when users click or hover over items. Since the logs and stats lists are purely for display and offer no interactive selection logic, this visual feedback can be misleading and confusing. Disabling selection makes the interface more predictable and removes an unnecessary affordance.

**📸 Before/After:**
- **Before:** Hovering over or clicking on log entries or stats items triggered visual highlights.
- **After:** No visual response occurs when interacting with these purely informational lists.

**♿ Accessibility:**
Improves cognitive accessibility by removing misleading interactive cues from non-interactive content, ensuring users do not expect actions to result from clicking these items.

---
*PR created automatically by Jules for task [17049589218013132972](https://jules.google.com/task/17049589218013132972) started by @hxy91819*