### PR TITLE
docs: align HDR documentation with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   - **WMI 监控**: 兼容性最好，适用于所有 Windows 版本
   - **ETW 监控**: 低延迟高性能，需要管理员权限
 - **游戏时间统计**: 记录每个游戏的运行时间
-- **HDR 控制**: 为将来的 HDR 自动切换预留接口（当前为空实现）
+- **HDR 控制**: 检测多显示器 HDR 支持状态，并在游戏会话中通过 Win+Alt+B 系统快捷键自动切换；显示器不支持或被 Windows 强制禁用时跳过
 - **配置管理**: 支持 YAML 配置文件，可添加/移除游戏
 - **交互式命令行**: 默认提供图形化的终端界面，可视化管理监控、配置、统计与工具
 - **自动降级**: ETW 监控失败时自动回退到 WMI 监控
@@ -111,14 +111,14 @@ games:
 - `name`: 匹配进程名（大小写不敏感）
 - `alias`: 显示名称
 - `isEnabled`: 是否启用该游戏的所有自动化功能
-- `hdrEnabled`: 为将来 HDR 控制预留，当前不会实际切换 HDR
+- `hdrEnabled`: 启用后，当该游戏运行时 `WindowsHdrController` 会尝试开启 HDR；当所有标记此项的游戏都退出后会尝试关闭
 
 ### 自动化工作流程
 
 1. **进程检测**: 使用 WMI 或 ETW 监控系统进程启动/退出事件
 2. **游戏识别**: 根据配置文件中的 `name` 字段匹配进程
 3. **状态管理**: 跟踪活跃游戏进程，记录启动/停止时间
-4. **HDR 控制**: 当有游戏运行时调用 HDR 控制器（当前为空实现）
+4. **HDR 控制**: 当有 `hdrEnabled: true` 的游戏运行时，`WindowsHdrController` 通过 Win+Alt+B 注入切换 HDR；显示器不支持或 Windows 报告 ForceDisabled 时跳过
 5. **时间统计**: 将游戏运行时间保存到 CSV 文件
 
 ### 进程监控方式对比
@@ -241,7 +241,7 @@ processMonitorType: ETW  # 默认值，可省略
 games:
   - name: "game.exe"
     isEnabled: true    # 只监控需要的游戏
-    hdrEnabled: false  # 暂时禁用未实现的功能
+    hdrEnabled: false  # 是否在该游戏运行时切换 HDR
 
 # 兼容性配置（无管理员权限）
 processMonitorType: WMI
@@ -261,9 +261,10 @@ games:
   - [ ] 只监听配置列表中的进程
   - [ ] 游戏第一次停止之后，记录fuzzyname，下次可以进行精准进程监听，进一步提升性能
 - [ ] 弱提示，避免魂游这类游戏被误终止
-- [ ] 自动开关HDR
-  - [ ] 检测当前HDR开启状态
-  - [ ] 提前开启HDR，避免部分游戏内部未识别HDR（当前实现太粗糙，遇到核心技术问题，暂缓实现）
+- [x] 自动开关HDR
+  - [x] 检测当前HDR开启状态（基于 Windows DisplayConfig API，多显示器感知）
+  - [x] 游戏启动/结束时自动切换（通过 SendInput 注入 Win+Alt+B，回退至 keybd_event）
+  - [ ] 评估改用 `DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE` SET API，避免依赖前台焦点
 
 ### 游戏库管理与发现
 - [x] 拖动图标到程序上自动添加
@@ -354,5 +355,5 @@ ProcessMonitorFactory
 - **默认使用 ETW 监控**，需要管理员权限才能正常运行
 - 如果 ETW 初始化失败，程序会自动降级到 WMI 监控
 - 如无法获得管理员权限，建议在配置文件中显式设置 `processMonitorType: WMI`
-- HDR 切换当前未实现（NoOp），仅记录会话与统计数据
+- HDR 切换基于 Win+Alt+B 注入，依赖前台焦点与桌面会话；显示器不支持或被 Windows 强制禁用时自动跳过
 - 程序不会收集或上传任何个人数据

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,7 +178,7 @@ GameHelper/
 
 ## 7. Technical Debt and Known Issues
 
-1.  **HDR 功能**: `IHdrController` 的实现 `NoOpHdrController` 是一个空操作。如 `README.md` 所述，实际的 HDR 自动切换功能因技术挑战而暂缓实现。
+1.  **HDR 切换路径**: `WindowsHdrController` 已实现 HDR 状态检测（基于 Windows DisplayConfig API：`GetDisplayConfigBufferSizes` + `QueryDisplayConfig` + `DisplayConfigGetDeviceInfo` with `DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO`，多显示器感知，识别支持/启用/`ForceDisabled` 三态）和切换（通过 `SendInput` 注入 Win+Alt+B，失败时回退至 `keybd_event`）。`NoOpHdrController` 仅作为非 Windows 环境的占位实现。**已知限制**：当前切换路径依赖前台焦点与桌面会话状态，不适用于无人值守服务场景；`DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE`（type 10）的 SET API 已在枚举中声明但尚未启用作为切换路径，是否引入待评估。
 2.  **进程过滤 (已更新状态: 明确推迟)**: 原始架构 指出，当前的 WMI/ETW 监控 会监听所有进程，然后在 `GameAutomationService` 中进行过滤，并建议未来进行优化。
       * **更新决策:** 此项优化（即在 WMI/ETW 级别 预先过滤）已被*明确推迟*。
       * **理由:** 为了支持新的 L2 回退匹配逻辑（使用文件元数据 和模糊匹配 来处理如 `cheatenginex8664sse4avx2.exe` 这样的变体名称），系统*必须*继续监听所有进程启动事件，以捕获它们的完整路径和名称。预过滤已被证实是不可靠的。我们将接受在服务级别 进行过滤所带来的性能开销。

--- a/docs/architecture/7-technical-debt-and-known-issues.md
+++ b/docs/architecture/7-technical-debt-and-known-issues.md
@@ -1,6 +1,6 @@
 # 7. Technical Debt and Known Issues
 
-1.  **HDR 功能**: `IHdrController` 的实现 `NoOpHdrController` 是一个空操作。如 `README.md` 所述，实际的 HDR 自动切换功能因技术挑战而暂缓实现。
+1.  **HDR 切换路径**: `WindowsHdrController` 已实现 HDR 状态检测（基于 Windows DisplayConfig API：`GetDisplayConfigBufferSizes` + `QueryDisplayConfig` + `DisplayConfigGetDeviceInfo` with `DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO`，多显示器感知，识别支持/启用/`ForceDisabled` 三态）和切换（通过 `SendInput` 注入 Win+Alt+B，失败时回退至 `keybd_event`）。`NoOpHdrController` 仅作为非 Windows 环境的占位实现。**已知限制**：当前切换路径依赖前台焦点与桌面会话状态，不适用于无人值守服务场景；`DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE`（type 10）的 SET API 已在枚举中声明但尚未启用作为切换路径，是否引入待评估。
 2.  **进程过滤 (已更新状态: 明确推迟)**: 原始架构 指出，当前的 WMI/ETW 监控 会监听所有进程，然后在 `GameAutomationService` 中进行过滤，并建议未来进行优化。
       * **更新决策:** 此项优化（即在 WMI/ETW 级别 预先过滤）已被*明确推迟*。
       * **理由:** 为了支持新的 L2 回退匹配逻辑（使用文件元数据 和模糊匹配 来处理如 `cheatenginex8664sse4avx2.exe` 这样的变体名称），系统*必须*继续监听所有进程启动事件，以捕获它们的完整路径和名称。预过滤已被证实是不可靠的。我们将接受在服务级别 进行过滤所带来的性能开销。

--- a/docs/brownfield-architecture.md
+++ b/docs/brownfield-architecture.md
@@ -97,7 +97,7 @@ GameHelper/
 
 ## 6. 技术债务和已知问题
 
-1.  **HDR 功能**: `IHdrController` 的实现 `NoOpHdrController` 是一个空操作。如 `README.md` 所述，实际的 HDR 自动切换功能因技术挑战而暂缓实现。
+1.  **HDR 切换路径**: `WindowsHdrController` 已实现 HDR 状态检测（基于 Windows DisplayConfig API：`GetDisplayConfigBufferSizes` + `QueryDisplayConfig` + `DisplayConfigGetDeviceInfo` with `DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO`，多显示器感知，识别支持/启用/`ForceDisabled` 三态）和切换（通过 `SendInput` 注入 Win+Alt+B，失败时回退至 `keybd_event`）。`NoOpHdrController` 仅作为非 Windows 环境的占位实现。**已知限制**：当前切换路径依赖前台焦点与桌面会话状态，不适用于无人值守服务场景；`DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE`（type 10）的 SET API 已在枚举中声明但尚未启用作为切换路径，是否引入待评估。
 2.  **进程过滤**: 当前的 WMI/ETW 监控会监听所有进程，然后在 `GameAutomationService` 中进行过滤。`README.md` 提到未来可以优化为只监听配置列表中的进程，以提升性能。
 3.  **存档复制**: 自动复制存档（如魂类游戏）的功能仍在计划中，尚未实现。
 4.  **错误处理**: 尽管存在文件容错，但在某些边缘情况下，不正确的配置或损坏的 CSV 文件可能导致未经处理的异常。


### PR DESCRIPTION
Closes part of #34.

### Context

Multiple docs claim the HDR controller is a NoOp / "暂缓实现" (implementation deferred), but `Program.cs:107` registers `WindowsHdrController` as the production `IHdrController`, and that controller has had a real implementation for some time:

- **State detection** uses Windows DisplayConfig APIs: `GetDisplayConfigBufferSizes` → `QueryDisplayConfig` → `DisplayConfigGetDeviceInfo` with `DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO`. Multi-display aware; recognizes Supported / Enabled / `AdvancedColorForceDisabled` states.
- **Toggle** is performed by injecting the Win+Alt+B system shortcut via `SendInput`, falling back to `keybd_event`.
- `NoOpHdrController` only serves as the non-Windows placeholder.

This PR fixes the drifted documentation in 4 files. No code changes.

### What I changed

- `docs/architecture.md` §7.1 and `docs/architecture/7-technical-debt-and-known-issues.md` — replaced the "NoOp / 暂缓实现" claim with an accurate description of the detection and toggle paths. Kept the caveat about foreground-focus dependency and the open question about the unused `DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE` SET API.
- `docs/brownfield-architecture.md` §6 — same fix.
- `README.md` — six places: features list, `hdrEnabled` field doc, automation workflow step 4, config example comment, roadmap checkboxes (the HDR detection and toggle items are in fact done), and footer notes.

### What I deliberately did **not** change

- `docs/history/*` — these read like a logbook with point-in-time entries. Some descriptions (e.g. WORK_SUMMARY_zh.md, CLI_Manual_zh.md) state "current state" but are filed under `history/`; I wasn't sure of your intent. Happy to update those in a follow-up PR if you'd prefer them kept current.
- Any code. The implementation is already correct; only docs drifted.
- The caveat that Win+Alt+B injection has real limitations (foreground-focus dependency, no unattended-service support). Preserved verbatim where it appeared.

### Open question (also raised in #34 comment)

The enum at `WindowsHdrController.cs:470` declares `DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE = 10`, the SET counterpart of the GET API used for detection, but the value is never called — toggle goes through Win+Alt+B instead. Did you try the SET API and hit a specific issue? If you went straight to keystrokes for a known reason, I'd love to capture that as a one-line note in the same docs; otherwise this might be worth evaluating.

### Tests

No code changes; existing test suite untouched.
